### PR TITLE
upgrade buildToolsVersion to the closest version that is actually hosted and can be downloaded

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.databinding'
 
 android {
     compileSdkVersion 22
-    buildToolsVersion '23.0.0 rc1'
+    buildToolsVersion '23.0.1'
 
     defaultConfig {
         applicationId 'com.chaos.databinding'


### PR DESCRIPTION
    ./gradlew tasks
would not run, and the version of the build tools specified was not available for download. 23.0.1 is the lowest higher version available via the SDK Manager.